### PR TITLE
feat: add the file id to the return from the gdrive mcp server

### DIFF
--- a/a2a/iag-mcp-demo/drive_mcp/vendor/index.js
+++ b/a2a/iag-mcp-demo/drive_mcp/vendor/index.js
@@ -130,7 +130,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             fields: "files(id, name, mimeType, modifiedTime, size)",
         });
         const fileList = res.data.files
-            ?.map((file) => `${file.name} (${file.mimeType})`)
+            ?.map((file) => `${file.id} ${file.name} (${file.mimeType})`)
             .join("\n");
         return {
             content: [


### PR DESCRIPTION
Adds the file uuid value back to the data that is returned for a matching file from gDrive.